### PR TITLE
Fix example resume schema errors

### DIFF
--- a/example-resume.json
+++ b/example-resume.json
@@ -173,10 +173,5 @@
       "description": "A responsive Bootstrap one page theme designed to help app developers promote their mobile apps.",
       "url": "http://themes.3rdwavemedia.com/website-templates/responsive-bootstrap-theme-for-mobile-apps-delta/"
     }
-  ],
-  "meta": {
-    "canonical": "https://raw.githubusercontent.com/jsonresume/resume-schema/master/resume.json",
-    "version": "v1.0.0",
-    "lastModified": "2017-12-24T15:53:00"
-  }
+  ]
 }

--- a/example-resume.json
+++ b/example-resume.json
@@ -31,7 +31,6 @@
       "location": "San Francisco",
       "position": "Lead Developer",
       "startDate": "2015-12-01",
-      "endDate": "",
       "summary": "Describe your role here lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat massa quis enim. Donec pede justo.  Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo."
     },
     {


### PR DESCRIPTION
After PR validation still fails as validator doesn't allow properties that aren't in the schema.
Our resume includes a `projects` section.