### PR TITLE
npm 8 no longer supports node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js: '10'
 
 before_install:
-- npm install -g npm@latest
+- npm install -g npm@7.x.x
 
 install:
 - npm ci


### PR DESCRIPTION
Fix npm version at 7.x.x

https://github.blog/changelog/2021-10-07-npm-cli-upgraded-to-version-8/