### PR TITLE
Use white margins in pdf

### DIFF
--- a/assets/css/styles-1.css
+++ b/assets/css/styles-1.css
@@ -307,6 +307,7 @@ ul {
   html,
   body {
     width: 1020px;
+    background: white;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
   }

--- a/assets/css/styles-2.css
+++ b/assets/css/styles-2.css
@@ -307,6 +307,7 @@ ul {
   html,
   body {
     width: 1020px;
+    background: white;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
   }

--- a/assets/css/styles-3.css
+++ b/assets/css/styles-3.css
@@ -307,6 +307,7 @@ ul {
   html,
   body {
     width: 1020px;
+    background: white;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
   }

--- a/assets/css/styles-4.css
+++ b/assets/css/styles-4.css
@@ -307,6 +307,7 @@ ul {
   html,
   body {
     width: 1020px;
+    background: white;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
   }

--- a/assets/css/styles-5.css
+++ b/assets/css/styles-5.css
@@ -307,6 +307,7 @@ ul {
   html,
   body {
     width: 1020px;
+    background: white;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
   }

--- a/assets/css/styles-6.css
+++ b/assets/css/styles-6.css
@@ -307,6 +307,7 @@ ul {
   html,
   body {
     width: 1020px;
+    background: white;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
   }

--- a/assets/less/default/responsive.less
+++ b/assets/less/default/responsive.less
@@ -63,6 +63,7 @@
 @media print {
     html, body {
         width: 1020px;
+        background: white;
         -webkit-print-color-adjust:exact !important;
         print-color-adjust:exact !important;
     }

--- a/index.js
+++ b/index.js
@@ -155,18 +155,9 @@ module.exports = {
 	render: render,
 	pdfRenderOptions: {
 		mediaType: 'print',
-		displayHeaderFooter: true,
 		margin: {
 			top: '30px',
 			bottom: '30px'
-		},
-		headerTemplate: `
-			<style>
-				html {
-				  -webkit-print-color-adjust: exact;
-				}
-			</style>
-			<div style="margin-top: -30px; background: #f5f5f5; width: 100%; height: 2000px"/>    
-		`
+		}
 	}
 };


### PR DESCRIPTION
Margin behaviour is very different in different versions of puppeteer/chromium.
White margin is simpler and could be argued that it looks better as the missing top padding on pages after the first is less obvious

With grey border:
<img width="1084" alt="Screenshot 2024-10-24 at 17 24 44" src="https://github.com/user-attachments/assets/fd9a5bbe-8eaf-44d6-a6d2-ffb445d0edb6">

With white border:

<img width="1082" alt="Screenshot 2024-10-24 at 17 27 52" src="https://github.com/user-attachments/assets/7dc89851-3d01-4704-807c-936efe799b47">
